### PR TITLE
Ajuste Textos Notificaciones Reaseguro

### DIFF
--- a/Objetos-BD/Paquetes/oc_procesos_masivos.sql
+++ b/Objetos-BD/Paquetes/oc_procesos_masivos.sql
@@ -10523,7 +10523,7 @@ BEGIN
                 cRFCBenef         := LTRIM(OC_PROCESOS_MASIVOS.VALOR_CAMPO(X.RegDatosProc,23,cSeparador));
                 cNombProvBenef    := LTRIM(OC_PROCESOS_MASIVOS.VALOR_CAMPO(X.RegDatosProc,24,cSeparador));
 
-                IF LENGTH(REPLACE(LTRIM(RTRIM(REPLACE(cRFCBenef,' '))),'-')) <> 13 THEN
+                IF LENGTH(REPLACE(LTRIM(RTRIM(REPLACE(cRFCBenef,' '))),'-')) NOT between 12 and 13 THEN
                     cMsjError := ' RFC De Beneficiario De Pago '||cRFCBenef||' No Cumple Con La Longitud Establecida De 13 Caracteres, Por Favor Valide';
                     RAISE_APPLICATION_ERROR(-20225,'RFC De Beneficiario De Pago '||cRFCBenef||' No Cumple Con La Longitud Establecida De 13 Caracteres, Por Favor Valide');
                 END IF;


### PR DESCRIPTION
Se realizan ajustes en los textos de notificación de reaseguro facultativo para pólizas y cotizaciones